### PR TITLE
Fix initial color and font dialogs 

### DIFF
--- a/src/settings_dialog.cpp
+++ b/src/settings_dialog.cpp
@@ -93,7 +93,7 @@ void SettingsDialog::connectSignals()
     });
 
     connect(ui->fillColorPicker, &QPushButton::clicked, this, [=](){
-        changeColorSetting(ui->strokeColorPicker, "fillColor");
+        changeColorSetting(ui->fillColorPicker, "fillColor");
     });
 
     connect(ui->strokeColorPicker, &QPushButton::clicked, this, [=](){
@@ -119,7 +119,7 @@ void SettingsDialog::connectSignals()
 
 void SettingsDialog::changeColorSetting(QPushButton *colorPicker, QString colorSettingName)
 {
-    QColor color = QColorDialog::getColor();
+    QColor color = QColorDialog::getColor((*settings)[colorSettingName].value<QColor>());
     updateSetting(colorSettingName, color);
     setColorPickerPalette(colorPicker, color);
 }

--- a/src/settings_dialog.cpp
+++ b/src/settings_dialog.cpp
@@ -127,7 +127,7 @@ void SettingsDialog::changeColorSetting(QPushButton *colorPicker, QString colorS
 void SettingsDialog::changeFontSetting(QPushButton *fontPicker, QString fontSettingName)
 {
     bool fontFound;
-    QFont font = QFontDialog::getFont(&fontFound);
+    QFont font = QFontDialog::getFont(&fontFound, (*settings)[fontSettingName].value<QFont>());
 
     if (fontFound)
     {


### PR DESCRIPTION
Set initial values when opening the color or font dialog in the settings menu.